### PR TITLE
Features/add-bootstrap-settings-options-page

### DIFF
--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -19,7 +19,8 @@ define('ADD_BOOTSTRAP', [
     ],
     'fields' => [
         'version' => 'bootstrap_version',
-    ]
+        'enable_css' => 'bootstap_enable_css',
+    ],
 ]);
 
 add_action('admin_menu', function() {
@@ -70,5 +71,15 @@ add_action('admin_init', function() {
         },
         ADD_BOOTSTRAP['options']['page_slug'],
         ADD_BOOTSTRAP['options']['section_slug']
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['fields']['enable_css'],
+        [
+            'type' => 'boolean',
+            'sanitize_callback' => 'bool',
+            'default' => true,
+        ]
     );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -11,21 +11,32 @@
  * Requires PHP:        7.4
  */
 
-function render_bootstap_settings_page() {
-    echo <<<HTML
-    <div>
-        <h1>Bootstrap Settings</h1>
-        <p>Edit Bootstrap settings</p>
-    </div>
-HTML;
-}
+define('ADD_BOOTSTRAP', [
+    'options' => [
+        'page_slug' => 'bootstrap-settings',
+        'section_slug' => 'bootstrap_settings_section',
+    ],
+]);
 
 add_action('admin_menu', function() {
     add_theme_page(
         'Bootstrap Settings',
         'Bootstrap',
         'edit_theme_options',
-        'bootstrap-settings',
-        'render_bootstap_settings_page'
+        ADD_BOOTSTRAP['options']['page_slug'],
+        function () {
+            echo '<div>
+                <h1>'. get_admin_page_title() . '</h1>
+            </div>';
+        }
+    );
+});
+
+add_action('admin_init', function() {
+    add_settings_section(
+        ADD_BOOTSTRAP['options']['section_slug'],
+        'Settings',
+        '',
+        ADD_BOOTSTRAP['options']['page_slug']
     );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -31,6 +31,11 @@ add_action('admin_menu', function() {
         function () {
             echo '<div>
                 <h1>'. get_admin_page_title() . '</h1>
+                <form method="post" action="options.php">';
+                    settings_fields(ADD_BOOTSTRAP['options']['group_slug']);
+                    do_settings_sections(ADD_BOOTSTRAP['options']['page_slug']);
+                    submit_button();
+                echo '</form>
             </div>';
         }
     );

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -53,4 +53,17 @@ add_action('admin_init', function() {
             'default' => '',
         ]
     );
+    add_settings_field(
+        ADD_BOOTSTRAP['fields']['version'],
+        'Version',
+        function() {
+            printf(
+                '<input type="text" id="%1$s" name="%1$s" value="%2$s">',
+                ADD_BOOTSTRAP['fields']['version'],
+                get_option(ADD_BOOTSTRAP['fields']['version'])
+            );
+        },
+        ADD_BOOTSTRAP['options']['page_slug'],
+        ADD_BOOTSTRAP['options']['section_slug']
+    );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -10,3 +10,22 @@
  * Requires at least:   5.9
  * Requires PHP:        7.4
  */
+
+function render_bootstap_settings_page() {
+    echo <<<HTML
+    <div>
+        <h1>Bootstrap Settings</h1>
+        <p>Edit Bootstrap settings</p>
+    </div>
+HTML;
+}
+
+add_action('admin_menu', function() {
+    add_theme_page(
+        'Bootstrap Settings',
+        'Bootstrap',
+        'edit_theme_options',
+        'bootstrap-settings',
+        'render_bootstap_settings_page'
+    );
+});

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -20,6 +20,7 @@ define('ADD_BOOTSTRAP', [
     'fields' => [
         'version' => 'bootstrap_version',
         'enable_css' => 'bootstap_enable_css',
+        'enable_js' => 'bootstrap_enable_js',
     ],
 ]);
 
@@ -97,5 +98,15 @@ add_action('admin_init', function() {
         },
         ADD_BOOTSTRAP['options']['page_slug'],
         ADD_BOOTSTRAP['options']['section_slug']
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['fields']['enable_js'],
+        [
+            'type' => 'boolean',
+            'sanitize_callback' => 'bool',
+            'default' => false,
+        ]
     );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -109,4 +109,20 @@ add_action('admin_init', function() {
             'default' => false,
         ]
     );
+    add_settings_field(
+        ADD_BOOTSTRAP['fields']['enable_js'],
+        'Enable JS',
+        function() {
+            $option_value = get_option(ADD_BOOTSTRAP['fields']['enable_js']);
+
+            printf(
+                '<input type="checkbox" id="%1$s" name="%1$s" value="%2$s" %3$s>',
+                ADD_BOOTSTRAP['fields']['enable_js'],
+                $option_value,
+                $option_value ? 'checked' : ''
+            );
+        },
+        ADD_BOOTSTRAP['options']['page_slug'],
+        ADD_BOOTSTRAP['options']['section_slug']
+    );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -82,4 +82,20 @@ add_action('admin_init', function() {
             'default' => true,
         ]
     );
+    add_settings_field(
+        ADD_BOOTSTRAP['fields']['enable_css'],
+        'Enable CSS',
+        function() {
+            $option_value = get_option(ADD_BOOTSTRAP['fields']['enable_css']);
+
+            printf(
+                '<input type="checkbox" id="%1$s" name="%1$s" value="%2$s" %3$s>',
+                ADD_BOOTSTRAP['fields']['enable_css'],
+                $option_value,
+                $option_value ? 'checked' : ''
+            );
+        },
+        ADD_BOOTSTRAP['options']['page_slug'],
+        ADD_BOOTSTRAP['options']['section_slug']
+    );
 });

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -15,7 +15,11 @@ define('ADD_BOOTSTRAP', [
     'options' => [
         'page_slug' => 'bootstrap-settings',
         'section_slug' => 'bootstrap_settings_section',
+        'group_slug' => 'bootstap_settings',
     ],
+    'fields' => [
+        'version' => 'bootstrap_version',
+    ]
 ]);
 
 add_action('admin_menu', function() {
@@ -38,5 +42,15 @@ add_action('admin_init', function() {
         'Settings',
         '',
         ADD_BOOTSTRAP['options']['page_slug']
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['fields']['version'],
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+        ]
     );
 });


### PR DESCRIPTION
Registered the plugin **Options Page** (`bootstrap-settings`) with initial settings fields

- added `bootstrap-settings` main **Options Page**
- added **text input** field for `version` to use
- added **checkbox** field to enable / disable **CSS**
- added **checkbox** field to enable / disable **JS**