### PR TITLE
Features/refactor-options-page-with-js-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
+/build
 /package-lock.json

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -39,11 +39,6 @@ add_action('admin_menu', function() {
             echo '<div>
                 <h1>'. get_admin_page_title() . '</h1>
                 <div id="bootstrap-settings"></div>
-                <form method="post" action="options.php">';
-                    settings_fields(ADD_BOOTSTRAP['options']['group_slug']);
-                    do_settings_sections(ADD_BOOTSTRAP['options']['page_slug']);
-                    submit_button();
-                echo '</form>
             </div>';
         }
     );
@@ -90,13 +85,6 @@ function add_bootstrap_register_settings_fields() {
 
 add_action('admin_init', function () {
     add_bootstrap_register_settings_fields();
-
-    add_settings_section(
-        ADD_BOOTSTRAP['options']['section_slug'],
-        'Settings',
-        '',
-        ADD_BOOTSTRAP['options']['page_slug']
-    );
 });
 
 add_action('rest_api_init', function () {

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -107,6 +107,14 @@ add_action('admin_enqueue_scripts', function () {
             $assets_file['version'],
             true
         );
+        wp_localize_script(
+            'bootstrap-settings-admin-js',
+            'bootstrap_settings',
+            [
+                'fields' => ADD_BOOTSTRAP['fields'],
+                'versions' => ADD_BOOTSTRAP['versions'],
+            ]
+        );
 
         wp_enqueue_style('wp-components');
     }

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -126,22 +126,6 @@ add_action('admin_init', function () {
     );
 
     add_settings_field(
-        ADD_BOOTSTRAP['fields']['enable_css'],
-        'Enable CSS',
-        function() {
-            $option_value = get_option(ADD_BOOTSTRAP['fields']['enable_css']);
-
-            printf(
-                '<input type="checkbox" id="%1$s" name="%1$s" value="1" %2$s>',
-                ADD_BOOTSTRAP['fields']['enable_css'],
-                $option_value ? 'checked' : ''
-            );
-        },
-        ADD_BOOTSTRAP['options']['page_slug'],
-        ADD_BOOTSTRAP['options']['section_slug']
-    );
-
-    add_settings_field(
         ADD_BOOTSTRAP['fields']['enable_js'],
         'Enable JS',
         function() {

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -147,6 +147,25 @@ add_action('admin_init', function() {
     );
 });
 
+add_action('admin_enqueue_scripts', function () {
+    $current_screen = get_current_screen();
+    $options_page_id = 'appearance_page_' . ADD_BOOTSTRAP['options']['page_slug'];
+
+    if ($current_screen instanceof \WP_Screen
+        &&  $options_page_id === $current_screen->id
+    ) {
+        $assets_file = require_once(plugin_dir_path(__FILE__ ) . 'build/index.asset.php');
+
+        wp_enqueue_script(
+            'bootstrap-settings-admin-js',
+            plugin_dir_url(__FILE__) . 'build/index.js',
+            $assets_file['dependencies'],
+            $assets_file['version'],
+            true
+        );
+    }
+});
+
 add_action('wp_enqueue_scripts', function () {
     $version = get_option(ADD_BOOTSTRAP['fields']['version']);
 

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -178,6 +178,8 @@ add_action('admin_enqueue_scripts', function () {
             $assets_file['version'],
             true
         );
+
+        wp_enqueue_style('wp-components');
     }
 });
 

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -49,14 +49,7 @@ add_action('admin_menu', function() {
     );
 });
 
-add_action('admin_init', function() {
-    add_settings_section(
-        ADD_BOOTSTRAP['options']['section_slug'],
-        'Settings',
-        '',
-        ADD_BOOTSTRAP['options']['page_slug']
-    );
-
+function add_bootstrap_register_settings_fields() {
     register_setting(
         ADD_BOOTSTRAP['options']['group_slug'],
         ADD_BOOTSTRAP['fields']['version'],
@@ -70,6 +63,38 @@ add_action('admin_init', function() {
             'default' => '',
         ]
     );
+
+    register_setting(
+        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['fields']['enable_css'],
+        [
+            'type' => 'boolean',
+            'sanitize_callback' => 'rest_sanitize_boolean',
+            'default' => true,
+        ]
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['fields']['enable_js'],
+        [
+            'type' => 'boolean',
+            'sanitize_callback' => 'rest_sanitize_boolean',
+            'default' => false,
+        ]
+    );
+}
+
+add_action('admin_init', function() {
+    add_bootstrap_register_settings_fields();
+
+    add_settings_section(
+        ADD_BOOTSTRAP['options']['section_slug'],
+        'Settings',
+        '',
+        ADD_BOOTSTRAP['options']['page_slug']
+    );
+
     add_settings_field(
         ADD_BOOTSTRAP['fields']['version'],
         'Version',
@@ -97,15 +122,6 @@ add_action('admin_init', function() {
         ADD_BOOTSTRAP['options']['section_slug']
     );
 
-    register_setting(
-        ADD_BOOTSTRAP['options']['group_slug'],
-        ADD_BOOTSTRAP['fields']['enable_css'],
-        [
-            'type' => 'boolean',
-            'sanitize_callback' => 'rest_sanitize_boolean',
-            'default' => true,
-        ]
-    );
     add_settings_field(
         ADD_BOOTSTRAP['fields']['enable_css'],
         'Enable CSS',
@@ -122,15 +138,6 @@ add_action('admin_init', function() {
         ADD_BOOTSTRAP['options']['section_slug']
     );
 
-    register_setting(
-        ADD_BOOTSTRAP['options']['group_slug'],
-        ADD_BOOTSTRAP['fields']['enable_js'],
-        [
-            'type' => 'boolean',
-            'sanitize_callback' => 'rest_sanitize_boolean',
-            'default' => false,
-        ]
-    );
     add_settings_field(
         ADD_BOOTSTRAP['fields']['enable_js'],
         'Enable JS',

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -97,33 +97,6 @@ add_action('admin_init', function () {
         '',
         ADD_BOOTSTRAP['options']['page_slug']
     );
-
-    add_settings_field(
-        ADD_BOOTSTRAP['fields']['version'],
-        'Version',
-        function() {
-            $current_version = get_option(ADD_BOOTSTRAP['fields']['version']);
-
-            printf(
-                '<select id="%1$s" name="%1$s" value="%2$s">',
-                ADD_BOOTSTRAP['fields']['version'],
-                $current_version
-            );
-            echo '<option>Select a version</option>';
-
-            foreach(ADD_BOOTSTRAP['versions'] as $allowed_version) {
-                printf(
-                    '<option value="%1$s" %2$s>%1$s</option>',
-                    $allowed_version,
-                    $allowed_version === $current_version ? 'selected' : ''
-                );
-            }
-
-            echo '</select>';
-        },
-        ADD_BOOTSTRAP['options']['page_slug'],
-        ADD_BOOTSTRAP['options']['section_slug']
-    );
 });
 
 add_action('rest_api_init', function () {

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -38,6 +38,7 @@ add_action('admin_menu', function() {
         function () {
             echo '<div>
                 <h1>'. get_admin_page_title() . '</h1>
+                <div id="bootstrap-settings"></div>
                 <form method="post" action="options.php">';
                     settings_fields(ADD_BOOTSTRAP['options']['group_slug']);
                     do_settings_sections(ADD_BOOTSTRAP['options']['page_slug']);

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -61,6 +61,7 @@ function add_bootstrap_register_settings_fields() {
                     : null;
             },
             'default' => '',
+            'show_in_rest' => true,
         ]
     );
 
@@ -71,6 +72,7 @@ function add_bootstrap_register_settings_fields() {
             'type' => 'boolean',
             'sanitize_callback' => 'rest_sanitize_boolean',
             'default' => true,
+            'show_in_rest' => true,
         ]
     );
 
@@ -81,11 +83,12 @@ function add_bootstrap_register_settings_fields() {
             'type' => 'boolean',
             'sanitize_callback' => 'rest_sanitize_boolean',
             'default' => false,
+            'show_in_rest' => true,
         ]
     );
 }
 
-add_action('admin_init', function() {
+add_action('admin_init', function () {
     add_bootstrap_register_settings_fields();
 
     add_settings_section(
@@ -153,6 +156,10 @@ add_action('admin_init', function() {
         ADD_BOOTSTRAP['options']['page_slug'],
         ADD_BOOTSTRAP['options']['section_slug']
     );
+});
+
+add_action('rest_api_init', function () {
+    add_bootstrap_register_settings_fields();
 });
 
 add_action('admin_enqueue_scripts', function () {

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -124,22 +124,6 @@ add_action('admin_init', function () {
         ADD_BOOTSTRAP['options']['page_slug'],
         ADD_BOOTSTRAP['options']['section_slug']
     );
-
-    add_settings_field(
-        ADD_BOOTSTRAP['fields']['enable_js'],
-        'Enable JS',
-        function() {
-            $option_value = get_option(ADD_BOOTSTRAP['fields']['enable_js']);
-
-            printf(
-                '<input type="checkbox" id="%1$s" name="%1$s" value="1" %2$s>',
-                ADD_BOOTSTRAP['fields']['enable_js'],
-                $option_value ? 'checked' : ''
-            );
-        },
-        ADD_BOOTSTRAP['options']['page_slug'],
-        ADD_BOOTSTRAP['options']['section_slug']
-    );
 });
 
 add_action('rest_api_init', function () {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "version": "0.1.0",
   "scripts": {
     "wp-env": "wp-env",
+    "start": "wp-scripts start",
+    "build": "wp-scripts build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
     "@wordpress/env": "^5.9.0"
+  },
+  "dependencies": {
+    "@wordpress/scripts": "^25.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "@wordpress/env": "^5.9.0"
   },
   "dependencies": {
+    "@wordpress/components": "^23.2.0",
+    "@wordpress/core-data": "^6.2.0",
+    "@wordpress/data": "^8.2.0",
     "@wordpress/element": "^5.2.0",
     "@wordpress/scripts": "^25.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@wordpress/env": "^5.9.0"
   },
   "dependencies": {
+    "@wordpress/element": "^5.2.0",
     "@wordpress/scripts": "^25.2.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,15 +7,18 @@ import { Button, CheckboxControl } from "@wordpress/components";
 
 const OPTIONS_KEYS = {
   enableCSS: "bootstrap_enable_css",
+  enableJS: "bootstrap_enable_js",
 }
 
 export default function App() {
   const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enableCSS);
+  const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enableJS);
 
   const { saveEditedEntityRecord } = useDispatch(coreStore);
   const saveOptions = () => {
     saveEditedEntityRecord("root", "site", undefined, {
       [OPTIONS_KEYS.enableCSS]: enableCSS,
+      [OPTIONS_KEYS.enableJS]: enableJS
     });
   };
 
@@ -25,8 +28,13 @@ export default function App() {
       <div>
         <CheckboxControl
           label="Enable CSS"
-          checked={enableCSS | false}
+          checked={enableCSS ? enableJS : false}
           onChange={(newValue) => setEnableCSS(newValue)}
+        />
+        <CheckboxControl
+          label="Enable JS"
+          checked={enableJS ? enableJS : false}
+          onChange={(newValue) => setEnableJS(newValue)}
         />
       </div>
       <Button

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,9 @@ import {
   Button,
   CheckboxControl,
   SelectControl,
+  Notice,
 } from "@wordpress/components";
+import { useState } from '@wordpress/element';
 
 const {
   bootstrap_settings: BOOTSTRAP_SETTINGS,
@@ -21,10 +23,11 @@ export default function App() {
   const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_css);
   const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_js);
   const [version, setVersion] = useEntityProp("root", "site", OPTIONS_KEYS.version);
+  const [ isSuccessNoticeShown, showSuccessNotice ] = useState(false);
 
   const { saveEditedEntityRecord } = useDispatch(coreStore);
   const saveOptions = () => {
-    saveEditedEntityRecord("root", "site", undefined, {
+    return saveEditedEntityRecord("root", "site", undefined, {
       [OPTIONS_KEYS.enable_css]: enableCSS,
       [OPTIONS_KEYS.enable_js]: enableJS,
       [OPTIONS_KEYS.version]: version,
@@ -33,6 +36,15 @@ export default function App() {
 
   return (
     <div>
+      {isSuccessNoticeShown && (
+        <Notice
+          status="success"
+          onDismiss={() => showSuccessNotice(false)}
+          onRemove={() => showSuccessNotice(false)}
+        >
+          Settings saved!
+        </Notice>
+      )}
       <h2>Settings</h2>
       <div>
         <SelectControl
@@ -64,8 +76,10 @@ export default function App() {
       </div>
       <Button
         variant="primary"
-        onClick={() => saveOptions()}
-      >Save</Button>
+        onClick={() => saveOptions()
+          .then(() => showSuccessNotice(true))
+        }
+      >Save settings</Button>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,22 +3,34 @@ import {
   store as coreStore,
 } from "@wordpress/core-data";
 import { useDispatch } from "@wordpress/data";
-import { Button, CheckboxControl } from "@wordpress/components";
+import {
+  Button,
+  CheckboxControl,
+  SelectControl,
+} from "@wordpress/components";
 
 const OPTIONS_KEYS = {
+  version: "bootstrap_version",
   enableCSS: "bootstrap_enable_css",
   enableJS: "bootstrap_enable_js",
-}
+};
+const ALLOWED_VERSIONS = [
+  "3.3.7",
+  "4.6.2",
+  "5.0.2",
+];
 
 export default function App() {
   const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enableCSS);
   const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enableJS);
+  const [version, setVersion] = useEntityProp("root", "site", OPTIONS_KEYS.version);
 
   const { saveEditedEntityRecord } = useDispatch(coreStore);
   const saveOptions = () => {
     saveEditedEntityRecord("root", "site", undefined, {
       [OPTIONS_KEYS.enableCSS]: enableCSS,
-      [OPTIONS_KEYS.enableJS]: enableJS
+      [OPTIONS_KEYS.enableJS]: enableJS,
+      [OPTIONS_KEYS.version]: version,
     });
   };
 
@@ -26,6 +38,22 @@ export default function App() {
     <div>
       <h2>Settings</h2>
       <div>
+        <SelectControl
+          value={version}
+          onChange={(newValue) => setVersion(newValue)}
+          options={[
+            {
+              label: "Select an Option",
+              value: "",
+            },
+            ...ALLOWED_VERSIONS.map((version) => {
+              return {
+                label: version,
+                value: version,
+              };
+            })
+          ]}
+        />
         <CheckboxControl
           label="Enable CSS"
           checked={enableCSS ? enableJS : false}

--- a/src/App.js
+++ b/src/App.js
@@ -9,27 +9,24 @@ import {
   SelectControl,
 } from "@wordpress/components";
 
-const OPTIONS_KEYS = {
-  version: "bootstrap_version",
-  enableCSS: "bootstrap_enable_css",
-  enableJS: "bootstrap_enable_js",
-};
-const ALLOWED_VERSIONS = [
-  "3.3.7",
-  "4.6.2",
-  "5.0.2",
-];
+const {
+  bootstrap_settings: BOOTSTRAP_SETTINGS,
+} = window;
+const {
+  fields: OPTIONS_KEYS,
+  versions: ALLOWED_VERSIONS,
+} = BOOTSTRAP_SETTINGS;
 
 export default function App() {
-  const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enableCSS);
-  const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enableJS);
+  const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_css);
+  const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_js);
   const [version, setVersion] = useEntityProp("root", "site", OPTIONS_KEYS.version);
 
   const { saveEditedEntityRecord } = useDispatch(coreStore);
   const saveOptions = () => {
     saveEditedEntityRecord("root", "site", undefined, {
-      [OPTIONS_KEYS.enableCSS]: enableCSS,
-      [OPTIONS_KEYS.enableJS]: enableJS,
+      [OPTIONS_KEYS.enable_css]: enableCSS,
+      [OPTIONS_KEYS.enable_js]: enableJS,
       [OPTIONS_KEYS.version]: version,
     });
   };

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,38 @@
+import {
+  useEntityProp,
+  store as coreStore,
+} from "@wordpress/core-data";
+import { useDispatch } from "@wordpress/data";
+import { Button, CheckboxControl } from "@wordpress/components";
+
+const OPTIONS_KEYS = {
+  enableCSS: "bootstrap_enable_css",
+}
+
 export default function App() {
+  const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enableCSS);
+
+  const { saveEditedEntityRecord } = useDispatch(coreStore);
+  const saveOptions = () => {
+    saveEditedEntityRecord("root", "site", undefined, {
+      [OPTIONS_KEYS.enableCSS]: enableCSS,
+    });
+  };
+
   return (
     <div>
       <h2>Settings</h2>
+      <div>
+        <CheckboxControl
+          label="Enable CSS"
+          checked={enableCSS | false}
+          onChange={(newValue) => setEnableCSS(newValue)}
+        />
+      </div>
+      <Button
+        variant="primary"
+        onClick={() => saveOptions()}
+      >Save</Button>
     </div>
-  )
+  );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,7 @@
+export default function App() {
+  return (
+    <div>
+      <h2>Settings</h2>
+    </div>
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,12 @@
+import { render } from "@wordpress/element";
+
+import App from "./App";
+
+addEventListener("DOMContentLoaded", () => {
+  const $appContainer = document.getElementById("bootstrap-settings");
+
+  render(
+    <App />,
+    $appContainer
+  );
+});


### PR DESCRIPTION
Replaced **options page** view for **Bootstrap Settings** with a **JS** app

- added **JS** build and required dependencies:
  - `@wordpress/scripts`
  - `@wordpress/element`
  - `@wordpress/components`
  - `@wordpress/core-data`
  - `@wordpress/data`
 - registered options fields to REST API (to consume in **JS** app)
 - moved options page fields from **PHP** to **JS**