### PR TITLE
Features/add-dependencies-to-enqueue-before-bootstrap-assets

### DIFF
--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -22,6 +22,7 @@ define('ADD_BOOTSTRAP', [
         'enable_css' => 'bootstrap_enable_css',
         'enable_js' => 'bootstrap_enable_js',
         'css_dependencies' => 'bootstrap_css_dependencies',
+        'js_dependencies' => 'bootstrap_js_dependencies',
     ],
     'versions' => [
         '3.3.7',
@@ -93,6 +94,17 @@ function add_bootstrap_register_settings_fields() {
     register_setting(
         ADD_BOOTSTRAP['options_page']['group_slug'],
         ADD_BOOTSTRAP['fields']['css_dependencies'],
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
+            'show_in_rest' => true,
+        ]
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options_page']['group_slug'],
+        ADD_BOOTSTRAP['fields']['js_dependencies'],
         [
             'type' => 'string',
             'sanitize_callback' => 'sanitize_text_field',

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -144,11 +144,19 @@ add_action('wp_enqueue_scripts', function () {
 
     if (in_array($version, ADD_BOOTSTRAP['versions'])) {
         $is_css_enabled = get_option(ADD_BOOTSTRAP['fields']['enable_css']);
+        $css_dependencies = get_option(ADD_BOOTSTRAP['fields']['css_dependencies']);
+        
+        if (empty($css_dependencies)) {
+            $css_dependencies = [];
+        } else {
+            $css_dependencies = explode(", ", $css_dependencies);
+        }
+
         if ($is_css_enabled) {
             wp_enqueue_style(
                 'bootstrap-css',
                 'https://cdn.jsdelivr.net/npm/bootstrap@'. $version . '/dist/css/bootstrap.min.css',
-                [],
+                $css_dependencies,
                 $version
             );
         }

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -21,6 +21,7 @@ define('ADD_BOOTSTRAP', [
         'version' => 'bootstrap_version',
         'enable_css' => 'bootstrap_enable_css',
         'enable_js' => 'bootstrap_enable_js',
+        'css_dependencies' => 'bootstrap_css_dependencies',
     ],
     'versions' => [
         '3.3.7',
@@ -85,6 +86,17 @@ function add_bootstrap_register_settings_fields() {
             'type' => 'boolean',
             'sanitize_callback' => 'rest_sanitize_boolean',
             'default' => false,
+            'show_in_rest' => true,
+        ]
+    );
+
+    register_setting(
+        ADD_BOOTSTRAP['options_page']['group_slug'],
+        ADD_BOOTSTRAP['fields']['css_dependencies'],
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default' => '',
             'show_in_rest' => true,
         ]
     );

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -12,7 +12,7 @@
  */
 
 define('ADD_BOOTSTRAP', [
-    'options' => [
+    'options_page' => [
         'page_slug' => 'bootstrap-settings',
         'section_slug' => 'bootstrap_settings_section',
         'group_slug' => 'bootstap_settings',
@@ -41,7 +41,7 @@ add_action('admin_menu', function() {
         'Bootstrap Settings',
         'Bootstrap',
         'edit_theme_options',
-        ADD_BOOTSTRAP['options']['page_slug'],
+        ADD_BOOTSTRAP['options_page']['page_slug'],
         function () {
             echo '<div>
                 <h1>'. get_admin_page_title() . '</h1>
@@ -53,7 +53,7 @@ add_action('admin_menu', function() {
 
 function add_bootstrap_register_settings_fields() {
     register_setting(
-        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['options_page']['group_slug'],
         ADD_BOOTSTRAP['fields']['version'],
         [
             'type' => 'string',
@@ -68,7 +68,7 @@ function add_bootstrap_register_settings_fields() {
     );
 
     register_setting(
-        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['options_page']['group_slug'],
         ADD_BOOTSTRAP['fields']['enable_css'],
         [
             'type' => 'boolean',
@@ -79,7 +79,7 @@ function add_bootstrap_register_settings_fields() {
     );
 
     register_setting(
-        ADD_BOOTSTRAP['options']['group_slug'],
+        ADD_BOOTSTRAP['options_page']['group_slug'],
         ADD_BOOTSTRAP['fields']['enable_js'],
         [
             'type' => 'boolean',
@@ -100,7 +100,7 @@ add_action('rest_api_init', function () {
 
 add_action('admin_enqueue_scripts', function () {
     $current_screen = get_current_screen();
-    $options_page_id = 'appearance_page_' . ADD_BOOTSTRAP['options']['page_slug'];
+    $options_page_id = 'appearance_page_' . ADD_BOOTSTRAP['options_page']['page_slug'];
 
     if ($current_screen instanceof \WP_Screen
         &&  $options_page_id === $current_screen->id

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -156,15 +156,16 @@ add_action('wp_enqueue_scripts', function () {
 
     if (in_array($version, ADD_BOOTSTRAP['versions'])) {
         $is_css_enabled = get_option(ADD_BOOTSTRAP['fields']['enable_css']);
-        $css_dependencies = get_option(ADD_BOOTSTRAP['fields']['css_dependencies']);
-        
-        if (empty($css_dependencies)) {
-            $css_dependencies = [];
-        } else {
-            $css_dependencies = explode(", ", $css_dependencies);
-        }
 
         if ($is_css_enabled) {
+            $css_dependencies = get_option(ADD_BOOTSTRAP['fields']['css_dependencies']);
+        
+            if (empty($css_dependencies)) {
+                $css_dependencies = [];
+            } else {
+                $css_dependencies = explode(",", trim($css_dependencies));
+            }
+
             wp_enqueue_style(
                 'bootstrap-css',
                 'https://cdn.jsdelivr.net/npm/bootstrap@'. $version . '/dist/css/bootstrap.min.css',
@@ -181,7 +182,13 @@ add_action('wp_enqueue_scripts', function () {
             $script_url = $is_bootstrap_4_or_above
                 ? 'https://cdn.jsdelivr.net/npm/bootstrap@' . $version . '/dist/js/bootstrap.bundle.min.js'
                 : 'https://cdn.jsdelivr.net/npm/bootstrap@' . $version . '/dist/js/bootstrap.min.js';
-            $required_dependencies = [];
+            $js_dependencies = get_option(ADD_BOOTSTRAP['fields']['js_dependencies']);
+        
+            if (empty($js_dependencies)) {
+                $js_dependencies = [];
+            } else {
+                $js_dependencies = explode(",", trim($js_dependencies));
+            }
 
             if (!$is_bootstrap_5_or_above) {
                 $jquery_url = $is_bootstrap_4_or_above
@@ -196,13 +203,13 @@ add_action('wp_enqueue_scripts', function () {
                     true
                 );
 
-                $required_dependencies[] = 'bootstrap-jquery';
+                $js_dependencies[] = 'bootstrap-jquery';
             }
 
             wp_enqueue_script(
                 'bootstrap-js',
                 $script_url,
-                $required_dependencies,
+                $js_dependencies,
                 $version
             );
         }

--- a/add-bootstrap.php
+++ b/add-bootstrap.php
@@ -156,7 +156,6 @@ add_action('wp_enqueue_scripts', function () {
 
     if (in_array($version, ADD_BOOTSTRAP['versions'])) {
         $is_css_enabled = get_option(ADD_BOOTSTRAP['fields']['enable_css']);
-
         if ($is_css_enabled) {
             $css_dependencies = get_option(ADD_BOOTSTRAP['fields']['css_dependencies']);
         

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import {
   CheckboxControl,
   SelectControl,
   Notice,
+  TextControl,
 } from "@wordpress/components";
 import { useState } from '@wordpress/element';
 
@@ -20,9 +21,11 @@ const {
 } = BOOTSTRAP_SETTINGS;
 
 export default function App() {
+  const [version, setVersion] = useEntityProp("root", "site", OPTIONS_KEYS.version);
   const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_css);
   const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_js);
-  const [version, setVersion] = useEntityProp("root", "site", OPTIONS_KEYS.version);
+  const [cssDependencies, setCSSDependencies] = useEntityProp("root", "site", OPTIONS_KEYS.css_dependencies);
+
   const [ isSuccessNoticeShown, showSuccessNotice ] = useState(false);
 
   const { saveEditedEntityRecord } = useDispatch(coreStore);
@@ -31,6 +34,7 @@ export default function App() {
       [OPTIONS_KEYS.enable_css]: enableCSS,
       [OPTIONS_KEYS.enable_js]: enableJS,
       [OPTIONS_KEYS.version]: version,
+      [OPTIONS_KEYS.css_dependencies]: cssDependencies,
     });
   };
 
@@ -67,6 +71,15 @@ export default function App() {
           label="Enable CSS"
           checked={enableCSS ? enableJS : false}
           onChange={(newValue) => setEnableCSS(newValue)}
+        />
+        <TextControl
+          label="CSS dependencies"
+          help="Add comma-separated style slugs"
+          value={cssDependencies
+            ? cssDependencies
+            : ""
+          }
+          onChange={(newValue) => setCSSDependencies(newValue)}
         />
         <CheckboxControl
           label="Enable JS"

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ export default function App() {
   const [enableCSS, setEnableCSS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_css);
   const [enableJS, setEnableJS] = useEntityProp("root", "site", OPTIONS_KEYS.enable_js);
   const [cssDependencies, setCSSDependencies] = useEntityProp("root", "site", OPTIONS_KEYS.css_dependencies);
+  const [jsDependencies, setJSDependencies] = useEntityProp("root", "site", OPTIONS_KEYS.js_dependencies);
 
   const [ isSuccessNoticeShown, showSuccessNotice ] = useState(false);
 
@@ -85,6 +86,15 @@ export default function App() {
           label="Enable JS"
           checked={enableJS ? enableJS : false}
           onChange={(newValue) => setEnableJS(newValue)}
+        />
+        <TextControl
+          label="JS dependencies"
+          help="Add comma-separated script slugs"
+          value={jsDependencies
+            ? jsDependencies
+            : ""
+          }
+          onChange={(newValue) => setJSDependencies(newValue)}
         />
       </div>
       <Button


### PR DESCRIPTION
Added options and fields to enqueue `js` and `css` dependencies before **Bootstrap** assets

- added `css_dependencies` option and field for `css` dependencies
- added `js_dependencies` option and field for `js` dependencies